### PR TITLE
fix: id대신 access token으로 사용하도록 컨트롤러 변경

### DIFF
--- a/src/main/java/com/briefin/domain/users/controller/UsersController.java
+++ b/src/main/java/com/briefin/domain/users/controller/UsersController.java
@@ -7,10 +7,11 @@ import com.briefin.domain.users.service.ScrapsService;
 import com.briefin.domain.users.service.UsersService;
 import com.briefin.domain.users.service.WatchlistService;
 import com.briefin.global.apipayload.ApiResponse;
+import com.briefin.global.security.jwt.JwtUserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,24 +24,24 @@ public class UsersController {
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserResponseDto>> getMyInfo(
-            @RequestParam UUID userId //JWT 인증 구현 전 임시
+            @AuthenticationPrincipal JwtUserInfo jwtUserInfo
     ){
-        return ResponseEntity.ok(ApiResponse.success(usersService.getUser(userId)));
+        return ResponseEntity.ok(ApiResponse.success(usersService.getUser(jwtUserInfo.userId())));
     }
 
     @GetMapping("/scraps")
     public ResponseEntity<ApiResponse<ScrapNewsResponseDto>> getScrappedNews(
-            @RequestParam UUID userId, //JWT 인증 구현 전 임시
+            @AuthenticationPrincipal JwtUserInfo jwtUserInfo,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(ApiResponse.success(scrapsService.getScrappedNews(userId, page, size)));
+        return ResponseEntity.ok(ApiResponse.success(scrapsService.getScrappedNews(jwtUserInfo.userId(), page, size)));
     }
 
     @GetMapping("/watchlist")
     public ResponseEntity<ApiResponse<WatchlistResponseDto>> getWatchlist(
-            @RequestParam UUID userId //JWT 인증 구현 전 임시
+            @AuthenticationPrincipal JwtUserInfo jwtUserInfo
     ) {
-        return ResponseEntity.ok(ApiResponse.success(watchlistService.getWatchlist(userId)));
+        return ResponseEntity.ok(ApiResponse.success(watchlistService.getWatchlist(jwtUserInfo.userId())));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 23

## 📝작업 내용

> /api/users/me, /api/users/scraps, /api/users/watchlist 엔드포인트 JWT 인증 적용

>기존에 임시로 @RequestParam UUID userId로 받던 방식을 @AuthenticationPrincipal JwtUserInfo로 변경하여 Access Token 기반으로 사용자 정보를 가져오도록 수정했습니다.

>UsersController: 세 엔드포인트에서 @RequestParam UUID userId 제거 → @AuthenticationPrincipal JwtUserInfo jwtUserInfo로 교체

## 💬리뷰 요구사항(선택)

> 스웨거에서 테스트해봐주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 사용자 정보 조회 API의 인증 처리 방식을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->