### PR TITLE
feat: 뉴스 스크랩 취소 기능

### DIFF
--- a/src/main/java/com/briefin/domain/news/controller/NewsController.java
+++ b/src/main/java/com/briefin/domain/news/controller/NewsController.java
@@ -55,4 +55,13 @@ public class NewsController {
     ) {
         return ApiResponse.success(scrapsService.addScrap(jwtUserInfo.userId(), id));
     }
+
+    @Operation(summary = "뉴스 스크랩 취소")
+    @DeleteMapping("/{id}/scrap")
+    public ApiResponse<ScrapResponseDto> removeScrap(
+            @PathVariable Long id,
+            @AuthenticationPrincipal JwtUserInfo jwtUserInfo
+    ) {
+        return ApiResponse.success(scrapsService.removeScrap(jwtUserInfo.userId(), id));
+    }
 }

--- a/src/main/java/com/briefin/domain/users/repository/ScrapsRepository.java
+++ b/src/main/java/com/briefin/domain/users/repository/ScrapsRepository.java
@@ -16,4 +16,6 @@ public interface ScrapsRepository extends JpaRepository<Scraps, Long> {
     Page<Scraps> findByUserIdWithNews(UUID userId, Pageable pageable);
 
     boolean existsByUserIdAndNewsId(UUID userId, Long newsId);
+
+    java.util.Optional<Scraps> findByUserIdAndNewsId(UUID userId, Long newsId);
 }

--- a/src/main/java/com/briefin/domain/users/service/ScrapsService.java
+++ b/src/main/java/com/briefin/domain/users/service/ScrapsService.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 public interface ScrapsService {
     ScrapNewsResponseDto getScrappedNews(UUID userId, int page, int size);
     ScrapResponseDto addScrap(UUID userId, Long newsId);
+    ScrapResponseDto removeScrap(UUID userId, Long newsId);
 }

--- a/src/main/java/com/briefin/domain/users/service/ScrapsServiceImpl.java
+++ b/src/main/java/com/briefin/domain/users/service/ScrapsServiceImpl.java
@@ -91,4 +91,18 @@ public class ScrapsServiceImpl implements ScrapsService {
                 .scrapedAt(scrap.getCreatedAt())
                 .build();
     }
+
+    @Override
+    @Transactional
+    public ScrapResponseDto removeScrap(UUID userId, Long newsId) {
+        Scraps scrap = scrapsRepository.findByUserIdAndNewsId(userId, newsId)
+                .orElseThrow(() -> new BriefinException(ErrorCode.NEWS_SCRAP_NOT_FOUND));
+
+        scrapsRepository.delete(scrap);
+
+        return ScrapResponseDto.builder()
+                .newsId(newsId)
+                .isScraped(false)
+                .build();
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 38

## 📝작업 내용

> DELETE /api/news/{id}/scrap 뉴스 스크랩 취소 API 구현 
- ScrapsRepository: findByUserIdAndNewsId 메서드 추가
- ScrapsService / ScrapsServiceImpl: removeScrap 구현 (스크랩 없으면 404)
- NewsController: DELETE /{id}/scrap 엔드포인트 추가


## 💬리뷰 요구사항(선택)

> 스웨거를 통해서 스크랩 리스트에서 해당 뉴스가 삭제되는지 확인 부탁드립니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 저장한 뉴스 스크랩을 언제든 제거할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->