### PR TITLE
feat: 회원탈퇴 api

### DIFF
--- a/src/main/java/com/briefin/domain/news/repository/NewsViewRepository.java
+++ b/src/main/java/com/briefin/domain/news/repository/NewsViewRepository.java
@@ -2,6 +2,7 @@ package com.briefin.domain.news.repository;
 
 import com.briefin.domain.news.entity.NewsView;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -15,4 +16,8 @@ public interface NewsViewRepository extends JpaRepository<NewsView, Long> {
 
     @Query("SELECT COUNT(v) FROM NewsView v WHERE v.userId = :userId")
     long countByUserId(@Param("userId") UUID userId);
+
+    @Modifying
+    @Query("DELETE FROM NewsView v WHERE v.userId = :userId")
+    void deleteByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/briefin/domain/users/controller/UsersController.java
+++ b/src/main/java/com/briefin/domain/users/controller/UsersController.java
@@ -7,6 +7,7 @@ import com.briefin.domain.users.service.ScrapsService;
 import com.briefin.domain.users.service.UsersService;
 import com.briefin.domain.users.service.WatchlistService;
 import com.briefin.global.apipayload.ApiResponse;
+import com.briefin.global.security.util.CookieUtil;
 import com.briefin.global.security.jwt.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import jakarta.servlet.http.HttpServletResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -61,6 +63,18 @@ public class UsersController {
     public ResponseEntity<Void> removeWatch(@PathVariable Long id) {
         watchlistService.removeWatch(id, SecurityUtils.getCurrentUserId());
         return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteMe(
+            @AuthenticationPrincipal JwtUserInfo jwtUserInfo,
+            HttpServletResponse response
+    ) {
+        usersService.deleteUser(jwtUserInfo.userId());
+
+        CookieUtil.deleteRefreshTokenCookie(response);
+
+        return ResponseEntity.ok(ApiResponse.<Void>success(null));
     }
 
 }

--- a/src/main/java/com/briefin/domain/users/repository/ScrapsRepository.java
+++ b/src/main/java/com/briefin/domain/users/repository/ScrapsRepository.java
@@ -4,7 +4,9 @@ import com.briefin.domain.users.entity.Scraps;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
@@ -18,4 +20,8 @@ public interface ScrapsRepository extends JpaRepository<Scraps, Long> {
     boolean existsByUserIdAndNewsId(UUID userId, Long newsId);
 
     java.util.Optional<Scraps> findByUserIdAndNewsId(UUID userId, Long newsId);
+
+    @Modifying
+    @Query("DELETE FROM Scraps s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/briefin/domain/users/repository/WatchlistRepository.java
+++ b/src/main/java/com/briefin/domain/users/repository/WatchlistRepository.java
@@ -2,7 +2,9 @@ package com.briefin.domain.users.repository;
 
 import com.briefin.domain.users.entity.Watchlist;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,6 +19,10 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
 
     boolean existsByUserIdAndCompanyId(UUID userId, Long companyId);
     Optional<Watchlist> findByUserIdAndCompanyId(UUID userId, Long companyId);
+
+    @Modifying
+    @Query("DELETE FROM Watchlist w WHERE w.user.id = :userId")
+    void deleteByUserId(@Param("userId") UUID userId);
 
 
 

--- a/src/main/java/com/briefin/domain/users/service/UsersService.java
+++ b/src/main/java/com/briefin/domain/users/service/UsersService.java
@@ -5,5 +5,6 @@ import java.util.UUID;
 
 public interface UsersService {
     UserResponseDto getUser(UUID userId);
+    void deleteUser(UUID userId);
 }
 

--- a/src/main/java/com/briefin/domain/users/service/UsersServiceImpl.java
+++ b/src/main/java/com/briefin/domain/users/service/UsersServiceImpl.java
@@ -2,9 +2,13 @@ package com.briefin.domain.users.service;
 
 import com.briefin.domain.users.dto.UserResponseDto;
 import com.briefin.domain.users.entity.Users;
+import com.briefin.domain.users.repository.ScrapsRepository;
+import com.briefin.domain.users.repository.WatchlistRepository;
 import com.briefin.domain.users.repository.UsersRepository;
+import com.briefin.domain.news.repository.NewsViewRepository;
 import com.briefin.global.apipayload.code.status.ErrorCode;
 import com.briefin.global.apipayload.exception.BriefinException;
+import com.briefin.global.security.jwt.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,7 +19,12 @@ import java.util.UUID;
 @Slf4j
 @Transactional(readOnly = true)
 public class UsersServiceImpl implements UsersService{
-    private  final UsersRepository usersRepository;
+    private final UsersRepository usersRepository;
+    private final WatchlistRepository watchlistRepository;
+    private final ScrapsRepository scrapsRepository;
+    private final NewsViewRepository newsViewRepository;
+    private final RefreshTokenService refreshTokenService;
+
     @Override
     public UserResponseDto getUser(UUID userId){
         Users user = usersRepository.findById(userId)
@@ -25,5 +34,21 @@ public class UsersServiceImpl implements UsersService{
                 .email(user.getEmail())
                 .createdAt(user.getCreatedAt())
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void deleteUser(UUID userId) {
+        usersRepository.findById(userId)
+                .orElseThrow(() -> new BriefinException(ErrorCode.USER_NOT_FOUND));
+
+        watchlistRepository.deleteByUserId(userId);
+        scrapsRepository.deleteByUserId(userId);
+
+        newsViewRepository.deleteByUserId(userId);
+
+        refreshTokenService.delete(userId);
+
+        usersRepository.deleteById(userId);
     }
 }


### PR DESCRIPTION
#️⃣연관된 이슈

#64

📝작업 내용

JWT 기반 인증 구조에서 회원탈퇴 기능을 구현했습니다.

🎯 핵심 구현 내용
DELETE /api/users/me 회원탈퇴 API 추가
@AuthenticationPrincipal을 활용하여 로그인 사용자 식별
사용자 탈퇴 시 연관 데이터 함께 삭제
관심기업 (watchlist)
스크랩 뉴스 (scraps)
최근 본 뉴스 (news_views)
Redis에 저장된 refreshToken 삭제 (refresh:{userId})
refreshToken HttpOnly 쿠키 만료 처리
트랜잭션 적용 (@Transactional)으로 데이터 일관성 보장
FK 제약을 고려하여 연관 데이터 → 유저 순으로 삭제
📌 응답 방식
기존 프로젝트 규칙에 맞춰
→ 200 OK + ApiResponse 형태로 응답 처리
🖼️ 스크린샷 (선택)
회원탈퇴 API 호출 성공 (200 OK)
탈퇴 후 동일 계정 로그인 시 실패 확인 (401)
💬리뷰 요구사항(선택)
연관 데이터 삭제 방식이 적절한지 (Repository deleteByUserId 사용)
refreshToken 삭제 로직이 현재 Redis 구조와 잘 맞는지
회원탈퇴 API의 응답 방식 (200 + ApiResponse vs 204) 관련 의견
SecurityConfig에서 /api/users/me 보호 설정이 적절한지 확인 부탁드립니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자가 자신의 계정을 삭제할 수 있는 새로운 기능 추가
  * 계정 삭제 시 관련된 모든 사용자 데이터(구독 목록, 스크랩, 조회 기록, 토큰) 자동 정리
  * 계정 삭제 후 인증 쿠키 자동 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->