### PR TITLE
feat: 해외 뉴스 타이틀 한국어로 번역 후 보여주기

### DIFF
--- a/src/main/java/com/briefin/domain/disclosures/client/ChatGptClient.java
+++ b/src/main/java/com/briefin/domain/disclosures/client/ChatGptClient.java
@@ -19,7 +19,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ChatGptClient {
 
-    @Value("${openai.api.key}")
+    @Value("${openai.api-key}")
     private String openAiKey;
 
     private final WebClient openAiWebClient;

--- a/src/main/java/com/briefin/domain/news/converter/NewsConverter.java
+++ b/src/main/java/com/briefin/domain/news/converter/NewsConverter.java
@@ -10,10 +10,17 @@ public class NewsConverter {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
+    private static String resolveTitle(News news, NewsSummary summary) {
+        if (summary != null && "해외".equals(summary.getRegion()) && summary.getTitleKo() != null) {
+            return summary.getTitleKo();
+        }
+        return news.getTitle();
+    }
+
     public static NewsListResponseDTO toListDTO(News news, NewsSummary summary, List<NewsCompany> companies) {
         return new NewsListResponseDTO(
                 news.getId().toString(),
-                news.getTitle(),
+                resolveTitle(news, summary),
                 summary != null ? summary.getSummaryLine() : null,
                 summary != null ? summary.getCategory() : null,
                 summary != null ? summary.getRegion() : null,
@@ -27,7 +34,7 @@ public class NewsConverter {
                                                     List<NewsCompany> companies, List<String> relatedNewsIds) {
         return new NewsDetailResponseDTO(
                 news.getId().toString(),
-                news.getTitle(),
+                resolveTitle(news, summary),
                 news.getContent(),
                 summary != null ? summary.getSummaryLine() : null,
                 summary != null ? summary.getCategory() : null,
@@ -41,7 +48,7 @@ public class NewsConverter {
     public static NewsSearchResponseDTO toSearchDTO(News news, NewsSummary summary, List<NewsCompany> companies) {
         return new NewsSearchResponseDTO(
                 news.getId().toString(),
-                news.getTitle(),
+                resolveTitle(news, summary),
                 summary != null ? summary.getSummaryLine() : null,
                 summary != null ? summary.getCategory() : null,
                 news.getSource(),
@@ -53,7 +60,7 @@ public class NewsConverter {
     public static NewsRelatedResponseDTO toRelatedDTO(News news, NewsSummary summary) {
         return new NewsRelatedResponseDTO(
                 news.getId().toString(),
-                news.getTitle(),
+                resolveTitle(news, summary),
                 summary != null ? summary.getSummaryLine() : null,
                 summary != null ? summary.getCategory() : null,
                 news.getSource(),

--- a/src/main/java/com/briefin/domain/news/entity/NewsSummary.java
+++ b/src/main/java/com/briefin/domain/news/entity/NewsSummary.java
@@ -28,4 +28,7 @@ public class NewsSummary extends BaseEntity {
 
     @Column(length = 20)
     private String region;
+
+    @Column(columnDefinition = "TEXT")
+    private String titleKo;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 67

## 📝작업 내용

> 해외 뉴스의 타이틀을 한국어로 번역한 것을 보여주는 방식으로 변경하였습니다.

### 스크린샷 (선택)

<img width="919" height="567" alt="image" src="https://github.com/user-attachments/assets/1b3222f6-6b35-4ecb-bb2c-d773d9f401b4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 뉴스 제목이 요약 데이터의 한국어 제목을 우선 표시하도록 개선되었습니다.

* **정리**
  * OpenAI API 키 구성 속성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->